### PR TITLE
adds automatic support for all caps name variations in lexicon

### DIFF
--- a/data/master_backend.py
+++ b/data/master_backend.py
@@ -11,6 +11,9 @@ def read_lexicon(lfile):
             spent = entry.strip().split(",")
             for alternative in spent:
                 conversion[alternative] = spent[0]
+                # automatically create an all uppercase lexicon alternative
+                if alternative != alternative.upper():
+                    conversion[alternative.upper()] = spent[0]
     return conversion
 
 def parse_setup():

--- a/data/prepare_us_states.py
+++ b/data/prepare_us_states.py
@@ -14,7 +14,7 @@ with open("samplenames.txt") as inf:
             if country == "USA":
                 state = entry.split("/")[1].split("-")[0]
                 if state in conversion:
-                    print(entry.strip() + "\t" + state, file = outf)
+                    print(entry.strip() + "\t" + conversion[state.upper()], file = outf)
                 else:
                     print(entry.strip(), file = badsamples)
 badsamples.close()


### PR DESCRIPTION
-automatically creates an all-caps region name variation so user doesn't need to enter this manually in the lexicon file;
-updates the python script for the Quick Start example data set to take advantage of the new functionality